### PR TITLE
Improve RoomPlan export fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ For more information about the app and how it works, see
 [Create a 3D model of an interior room by guiding the user through an AR experience]
 (https://developer.apple.com/documentation/roomplan/create_a_3d_model_of_an_interior_room_by_guiding_the_user_through_an_ar_experience) in the
 developer documentation.
+
+## Export Accuracy
+
+The app exports the captured space to both **USDZ** and **JSON** formats. To
+provide architects with the most detailed reference possible, the export uses
+`CapturedRoom.ExportOption.all`. This option includes the parametric data and the
+raw mesh in the same USDZ file so downstream tools can choose the level of
+precision they require.

--- a/ScanPlan/ResultsViewController.swift
+++ b/ScanPlan/ResultsViewController.swift
@@ -990,11 +990,13 @@ class ResultsViewController: UIViewController, UITableViewDataSource, UITableVie
                              userInfo: [NSLocalizedDescriptionKey: "Failed to generate JSON data: \(error.localizedDescription)"])
             }
             
-            // Export USDZ with specific error handling
+            // Export USDZ with highest fidelity
+            // `.all` preserves both the parametric data and underlying mesh
+            // for accurate architectural reference.
             do {
-                try roomData.export(to: destinationURL, exportOptions: .parametric)
+                try roomData.export(to: destinationURL, exportOptions: .all)
             } catch {
-                throw NSError(domain: "AppErrorDomain", code: 102, 
+                throw NSError(domain: "AppErrorDomain", code: 102,
                              userInfo: [NSLocalizedDescriptionKey: "Failed to generate 3D model: \(error.localizedDescription)"])
             }
             
@@ -1055,8 +1057,8 @@ class ResultsViewController: UIViewController, UITableViewDataSource, UITableVie
                 try FileManager.default.removeItem(at: modelURL)
             }
             
-            // Export the USDZ model
-            try roomData.export(to: modelURL, exportOptions: .parametric)
+            // Export the USDZ model using `.all` for maximum detail
+            try roomData.export(to: modelURL, exportOptions: .all)
             
             // Save the URL for the QuickLook preview - ensure on main thread
             DispatchQueue.main.async { [weak self] in

--- a/ScanPlan/RoomCaptureViewController.swift
+++ b/ScanPlan/RoomCaptureViewController.swift
@@ -159,11 +159,13 @@ class RoomCaptureViewController: UIViewController, RoomCaptureViewDelegate, Room
                              userInfo: [NSLocalizedDescriptionKey: "Failed to generate JSON data: \(error.localizedDescription)"])
             }
             
-            // Export USDZ with specific error handling
+            // Export USDZ with highest available accuracy
+            // `.all` generates both a parametric representation and the raw mesh
+            // ensuring maximum geometric fidelity for professional workflows.
             do {
-                try finalResults.export(to: destinationURL, exportOptions: .parametric)
+                try finalResults.export(to: destinationURL, exportOptions: .all)
             } catch {
-                throw NSError(domain: "AppErrorDomain", code: 102, 
+                throw NSError(domain: "AppErrorDomain", code: 102,
                              userInfo: [NSLocalizedDescriptionKey: "Failed to generate 3D model: \(error.localizedDescription)"])
             }
             


### PR DESCRIPTION
## Summary
- export USDZ with `.all` for highest room detail
- document export accuracy option

## Testing
- `xcodebuild -list` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to explain that exported spatial data now includes both parametric and raw mesh information for improved accuracy and flexibility.

- **New Features**
  - Enhanced USDZ exports to include both parametric and raw mesh data, providing higher fidelity and greater compatibility with professional tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->